### PR TITLE
Load notifications data from API instead of DOM

### DIFF
--- a/src/background/RemotePontoon.js
+++ b/src/background/RemotePontoon.js
@@ -36,15 +36,11 @@ class RemotePontoon {
 
     /**
      * Get notifications page URL.
-     * @param utm_source to include into the URL
      * @returns {string}
      * @private
      */
-    _getNotificationsUrl(utm_source) {
-        if (utm_source !== undefined) {
-            return `${this._notificationsUrl}?utm_source=${utm_source}`;
-        }
-        return this._notificationsUrl;
+    _getNotificationsUrl() {
+        return `${this._notificationsUrl}?utm_source=pontoon-tools`;
     }
 
     /**
@@ -418,7 +414,7 @@ class RemotePontoon {
                     this._markAllNotificationsAsRead();
                     break;
                 case BackgroundPontoon.MessageType.TO_BACKGROUND.GET_NOTIFICATIONS_URL:
-                    return Promise.resolve(this._getNotificationsUrl('pontoon-tools'));
+                    return Promise.resolve(this._getNotificationsUrl());
                 case BackgroundPontoon.MessageType.TO_BACKGROUND.GET_SETTINGS_URL:
                     return Promise.resolve(this._getSettingsUrl('pontoon-tools'));
                 case BackgroundPontoon.MessageType.TO_BACKGROUND.GET_SIGN_IN_URL:

--- a/src/background/RemotePontoon.js
+++ b/src/background/RemotePontoon.js
@@ -13,9 +13,6 @@ class RemotePontoon {
     constructor(baseUrl, team, options) {
         this._baseUrl = baseUrl;
         this._baseUrlChangeListeners = new Set();
-        this._userDataUrl = this._baseUrl + '/user-data/';
-        this._notificationsUrl = this._baseUrl + '/notifications/';
-        this._markAsReadUrl = this._notificationsUrl + 'mark-all-as-read/';
         this._team = team;
         this._options = options;
         this._domParser = new DOMParser();
@@ -40,7 +37,7 @@ class RemotePontoon {
      * @private
      */
     _getNotificationsUrl() {
-        return `${this._notificationsUrl}?utm_source=pontoon-tools`;
+        return `${this._baseUrl}/notifications/?utm_source=pontoon-tools`;
     }
 
     /**
@@ -222,7 +219,7 @@ class RemotePontoon {
      * @public
      */
     updateNotificationsData() {
-        this._dataFetcher.fetchFromPontoonSession(this._userDataUrl).then(
+        this._dataFetcher.fetchFromPontoonSession(`${this._baseUrl}/user-data/?utm_source=pontoon-tools-automation`).then(
             (response) => response.json()
         ).then((userData) => {
             const notificationsDataObj = {};
@@ -459,7 +456,7 @@ class RemotePontoon {
     _markAllNotificationsAsRead() {
         const dataKey = 'notificationsData';
         Promise.all([
-            this._dataFetcher.fetchFromPontoonSession(this._markAsReadUrl),
+            this._dataFetcher.fetchFromPontoonSession(`${this._baseUrl}/notifications/mark-all-as-read/?utm_source=pontoon-tools-automation`),
             browser.storage.local.get(dataKey)
         ]).then(([
             response,

--- a/src/background/RemotePontoon.js
+++ b/src/background/RemotePontoon.js
@@ -176,17 +176,17 @@ class RemotePontoon {
 
     /**
      * Update notifications data in storage from user data response.
-     * @param userDataNotifications notifications from user data JSON
+     * @param userDataNotifications notifications object from user data JSON
      * @private
      */
     _updateNotificationsDataFromUserData(userDataNotifications) {
-        const notifications = userDataNotifications.notifications;
+        const notificationsArray = userDataNotifications.notifications;
 
         const notificationsDataObj = {};
         // TODO:
         // when https://github.com/mozilla/pontoon/pull/1311 is fixed and deployed
         // mapping `n` to `nObj` is not needed anymore
-        notifications.map((n) => {
+        notificationsArray.map((n) => {
             const nObj = n;
             nObj.date_iso = n.date_iso.split('+', 2).join('+');
             return nObj;

--- a/src/background/RemotePontoon.js
+++ b/src/background/RemotePontoon.js
@@ -175,27 +175,6 @@ class RemotePontoon {
     }
 
     /**
-     * Update notifications data in storage from user data response.
-     * @param userDataNotifications notifications object from user data JSON
-     * @private
-     */
-    _updateNotificationsDataFromUserData(userDataNotifications) {
-        const notificationsArray = userDataNotifications.notifications;
-
-        const notificationsDataObj = {};
-        // TODO:
-        // when https://github.com/mozilla/pontoon/pull/1311 is fixed and deployed
-        // mapping `n` to `nObj` is not needed anymore
-        notificationsArray.map((n) => {
-            const nObj = n;
-            nObj.date_iso = n.date_iso.split('+', 2).join('+');
-            return nObj;
-        }).forEach((n) => notificationsDataObj[n.id] = n);
-
-        browser.storage.local.set({notificationsData: notificationsDataObj});
-    }
-
-    /**
      * Update notifications data in storage from Pontoon page content.
      * @param pageContent
      * @private
@@ -245,8 +224,18 @@ class RemotePontoon {
     updateNotificationsData() {
         this._dataFetcher.fetchFromPontoonSession(this._userDataUrl).then(
             (response) => response.json()
-        ).then(
-            (userData) => this._updateNotificationsDataFromUserData(userData.notifications)
+        ).then((userData) => {
+            const notificationsDataObj = {};
+            // TODO:
+            // when https://github.com/mozilla/pontoon/pull/1311 is fixed and deployed
+            // mapping of `date_iso` is not needed anymore
+            userData.notifications.notifications.map((n) => {
+                n.date_iso = n.date_iso.split('+', 2).join('+');
+                return n;
+            }).forEach((n) => notificationsDataObj[n.id] = n);
+            return notificationsDataObj;
+        }).then(
+            (nData) => browser.storage.local.set({notificationsData: nData})
         ).catch(
             (error) => browser.storage.local.set({notificationsData: undefined})
         );

--- a/src/toolbar-button/js/NotificationsPopup.js
+++ b/src/toolbar-button/js/NotificationsPopup.js
@@ -1,6 +1,7 @@
 /**
  * Displays notifications in the browser-action popup.
  * @requires commons/js/Options.js, commons/js/BackgroundPontoonClient.js
+ * @requires moment
  */
 class NotificationsPopup {
     /**
@@ -52,8 +53,8 @@ class NotificationsPopup {
         }
         if (notification.actor) {
             const actorLink = document.createElement('a');
-            actorLink.textContent = notification.actor.text;
-            this._backgroundPontoonClient.getTeamProjectUrl(notification.actor.link).then(
+            actorLink.textContent = notification.actor.anchor || notification.actor.text;
+            this._backgroundPontoonClient.getTeamProjectUrl(notification.actor.url || notification.actor.link).then(
                 (teamProjectUrl) => actorLink.setAttribute('href', teamProjectUrl)
             );
             listItem.appendChild(actorLink);
@@ -65,13 +66,18 @@ class NotificationsPopup {
         }
         if (notification.target) {
             const targetLink = document.createElement('a');
-            targetLink.textContent = ` ${notification.target.text}`;
-            this._backgroundPontoonClient.getTeamProjectUrl(notification.target.link).then(
+            targetLink.textContent = ` ${notification.target.anchor || notification.target.text}`;
+            this._backgroundPontoonClient.getTeamProjectUrl(notification.target.url || notification.target.link).then(
                 (teamProjectUrl) => targetLink.setAttribute('href', teamProjectUrl)
             );
             listItem.appendChild(targetLink);
         }
-        if (notification.timeago) {
+        if (notification.date_iso) {
+            const timeago = document.createElement('div');
+            timeago.textContent = NotificationsPopup._timeAgo(new Date(notification.date_iso));
+            timeago.classList.add('timeago');
+            listItem.appendChild(timeago);
+        } else if (notification.timeago) {
             const timeago = document.createElement('div');
             timeago.textContent = notification.timeago;
             timeago.classList.add('timeago');
@@ -144,5 +150,26 @@ class NotificationsPopup {
             seeAllLink.classList.add('hidden');
             error.classList.remove('hidden');
         }
+    }
+
+    /**
+     * Return string of how much is the given date in past.
+     * @param date
+     * @returns {String}
+     * @private
+     * @static
+     */
+    static _timeAgo(date) {
+        const dateMoment = moment.utc(date);
+        if (!date || !dateMoment.isValid()) {
+            return '―';
+        }
+        const duration = moment.duration(moment.utc().diff(dateMoment));
+        const durationString = duration.format({
+            template: 'Y __, M __, W __, D __, h __, m __, s __',
+            largest: 2,
+            minValue: 60,
+        });
+        return `${durationString} ago`;
     }
 }

--- a/src/toolbar-button/js/NotificationsPopup.js
+++ b/src/toolbar-button/js/NotificationsPopup.js
@@ -53,6 +53,7 @@ class NotificationsPopup {
         }
         if (notification.actor) {
             const actorLink = document.createElement('a');
+            // TODO: remove notification.actor.text and notification.actor.link which are for backward compatibility only
             actorLink.textContent = notification.actor.anchor || notification.actor.text;
             this._backgroundPontoonClient.getTeamProjectUrl(notification.actor.url || notification.actor.link).then(
                 (teamProjectUrl) => actorLink.setAttribute('href', teamProjectUrl)
@@ -66,6 +67,7 @@ class NotificationsPopup {
         }
         if (notification.target) {
             const targetLink = document.createElement('a');
+            // TODO: remove notification.target.text and notification.target.link which are for backward compatibility only
             targetLink.textContent = ` ${notification.target.anchor || notification.target.text}`;
             this._backgroundPontoonClient.getTeamProjectUrl(notification.target.url || notification.target.link).then(
                 (teamProjectUrl) => targetLink.setAttribute('href', teamProjectUrl)

--- a/src/toolbar-button/js/TeamInfoPopup.js
+++ b/src/toolbar-button/js/TeamInfoPopup.js
@@ -1,6 +1,7 @@
 /**
  * Display team information in the browser-action popup.
  * @requires commons/js/Options.js, commons/js/BackgroundPontoonClient.js
+ * @requires moment
  */
 class TeamInfoPopup {
     /**


### PR DESCRIPTION
Regularly refresh data from `/user-data/` instead of the notifications page.

TODO:
- [ ] Let's wait a while until https://github.com/mozilla/pontoon/pull/1311 fixes the ISO format of dates provided.
- [x] Update wiki page about [data sources](https://github.com/MikkCZ/pontoon-tools/wiki/Data).
- [x] query tag for `pontoon-tools-automation`