### PR TITLE
Ignore Translate.Next when fetching notifications

### DIFF
--- a/src/background/RemotePontoon.js
+++ b/src/background/RemotePontoon.js
@@ -190,6 +190,8 @@ class RemotePontoon {
                 .map((n) => RemotePontoon._createNotificationsData(n))
                 .forEach((nObj) => notificationsDataObj[nObj.id] = nObj);
             browser.storage.local.set({notificationsData: notificationsDataObj});
+        } else if (page.title === 'Translate.Next') {
+            // Translate.Next does not contain notifications in DOM
         } else {
             browser.storage.local.set({notificationsData: undefined});
         }

--- a/src/background/RemotePontoon.js
+++ b/src/background/RemotePontoon.js
@@ -452,11 +452,9 @@ class RemotePontoon {
     _markAllNotificationsAsRead() {
         const dataKey = 'notificationsData';
         Promise.all([
-            browser.tabs.query({url: this.getBaseUrl() + '/*'}),
             this._dataFetcher.fetchFromPontoonSession(this._markAsReadUrl),
             browser.storage.local.get(dataKey)
         ]).then(([
-            pontoonTabs,
             response,
             storageItem
         ]) => {

--- a/src/content-scripts/notifications-bell-icon.js
+++ b/src/content-scripts/notifications-bell-icon.js
@@ -6,7 +6,8 @@
 'use strict';
 
 // Notifications bell icon, if there are any unread notifications.
-const unreadNotificationsIcon = document.querySelector('#notifications.unread .button .icon');
+const unreadNotificationsIcon = document.querySelector('#notifications.unread .button .icon') || document.querySelector('header .user-notifications-menu.unread');
+const unreadDOMElement = document.querySelector('#notifications.unread') || document.querySelector('header .user-notifications-menu.unread');
 const backgroundPontoonClient = new BackgroundPontoonClient();
 
 /**
@@ -42,7 +43,7 @@ function notificationsDataChangeListener(change) {
         .length;
     if (unreadNotifications === 0) {
         removeUnreadNotificationsIconClickListener();
-        document.getElementById('notifications').classList.remove('unread');
+        unreadDOMElement.classList.remove('unread');
     }
 }
 


### PR DESCRIPTION
fix #97 

TODO:
- [x] do not ask for sign in because notifications cannot be fetched from Translate.Next
- [x] update the bell icon in Translate.Next when notifications are read